### PR TITLE
Omit explicit entrypoint in sentry-cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -322,7 +322,6 @@ services:
       context: ./cron
       args:
         BASE_IMAGE: "$SENTRY_IMAGE"
-    entrypoint: "/entrypoint.sh"
     command: '"0 0 * * * gosu sentry sentry cleanup --days $SENTRY_EVENT_RETENTION_DAYS"'
   nginx:
     <<: *restart_policy


### PR DESCRIPTION
I was wondering why that line was there and found that it is unnecessarily repeating the default set in `cron/Dockerfile`.
Other uses of the same image do not set the entrypoint explicitly too, so this makes the definition more concise and self-consistent.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
